### PR TITLE
Redirects for /dapps & /oev-searchers

### DIFF
--- a/docs/dapps/index.md
+++ b/docs/dapps/index.md
@@ -1,0 +1,5 @@
+<script setup>
+if (typeof window !== 'undefined') {
+  window.location.href = '/dapps/overview/';
+}
+</script>

--- a/docs/oev-searchers/index.md
+++ b/docs/oev-searchers/index.md
@@ -1,0 +1,5 @@
+<script setup>
+if (typeof window !== 'undefined') {
+  window.location.href = '/oev-searchers/overview/';
+}
+</script>


### PR DESCRIPTION
# Problem Solved #131 

 /dapps and /oev-searchers previously went to a 404 page. This meant that there was no default behaviour for those links as the main pages for each were their respective /overview 's. /dapps and /oev-searchers now redirect to /dapps/overview and /oev-searchers/overview respectively.

Solved as per issue #131 for adding redirects to the site.