### PR TITLE
remove redirect for /dapis

### DIFF
--- a/docs/oev-searchers/sidebar.js
+++ b/docs/oev-searchers/sidebar.js
@@ -5,7 +5,7 @@ module.exports = [
     items: [
       {
         text: 'Overview',
-        link: '/oev-searchers',
+        link: '/oev-searchers/',
       },
     ],
   },

--- a/firebase.json
+++ b/firebase.json
@@ -1,12 +1,6 @@
 {
   "hosting": {
-    "redirects": [
-      {
-        "source": "/dapis",
-        "destination": "/dapis/reference/understand/",
-        "type": 301
-      }
-    ],
+    "redirects": [],
     "public": "docs/.vitepress/dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   }


### PR DESCRIPTION
Closes #133 

Removed the redirect from `firebase.json` as no longer needed 

I also fixed a link in the sidebar for OEV